### PR TITLE
Fix for command line parsing

### DIFF
--- a/hdpvrcutter.pl
+++ b/hdpvrcutter.pl
@@ -77,7 +77,7 @@ my $jobid = '';
 my $help = '';
 
 # Print the help if requested or no arguments are used
-usage() if ( @ARGV < 1 or GetOptions(
+usage() if ( @ARGV < 1 or !GetOptions(
                                        'verbose' => \$verbose,
                                        'debug' => \$debug,
                                        'dryrun' => \$dryrun,
@@ -94,6 +94,7 @@ usage() if ( @ARGV < 1 or GetOptions(
                                        'jobid=i' => \$jobid,
                                        'help|?|h' => \$help)
            );
+usage() if ( $help );
 
 sub usage
         {


### PR DESCRIPTION
This change partially reverts 2da6f572fb0a0397f9bb5835283f572aae9bb1dc that doesn't seem to work, and proposes a different fix to achieve what was probably intended.
